### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,4 +1,6 @@
 name: gitleaks
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ItsMavey/ItsBagelBot/security/code-scanning/1](https://github.com/ItsMavey/ItsBagelBot/security/code-scanning/1)

In general, fix this by adding an explicit `permissions` block either at the workflow root (applies to all jobs) or under the specific job that uses the `GITHUB_TOKEN`. The block should grant only the minimal permissions needed. For this workflow, which only checks out code and runs gitleaks, read access to repository contents is sufficient; no write permissions or other scopes are needed.

The single best fix, without changing existing functionality, is to add a root-level `permissions` section after the `name:` (or after `on:`) specifying `contents: read`. This will apply to all jobs (here, only `scan`) and ensure that the `GITHUB_TOKEN` used by `actions/checkout` and `gitleaks/gitleaks-action` has read-only access to the repository contents. No other scopes are evidently required from the snippet. Concretely, in `.github/workflows/gitleaks.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: gitleaks` and `on:` keys (or equivalently after `on:` but before `jobs:`; placing it near the top is clearer). No imports or extra definitions are needed, as this is declarative workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
